### PR TITLE
Allow connection consumers to force a reconnect

### DIFF
--- a/lib/em-jack/connection.rb
+++ b/lib/em-jack/connection.rb
@@ -284,6 +284,11 @@ module EMJack
       @close_df = EM::DefaultDeferrable.new
     end
 
+    def force_reconnect
+      @intentionally_closed = false
+      @conn.close_connection if connected?
+    end
+
     def disconnected
       @connected = false
       if @intentionally_closed

--- a/lib/em-jack/connection.rb
+++ b/lib/em-jack/connection.rb
@@ -51,7 +51,7 @@ module EMJack
         initialize_tube_state
       end
 
-      @intentionally_closed = false
+      @desired_state = :connected
     end
 
     def initialize_tube_state
@@ -275,23 +275,20 @@ module EMJack
       @use_on_connect = nil
       @watch_on_connect = nil
 
-      @conn.close_connection_after_writing if @intentionally_closed
+      if @desired_state == :disconnected
+        @conn.close_connection_after_writing
+      end
     end
 
     def disconnect
-      @intentionally_closed = true
+      @desired_state = :disconnected
       @conn.close_connection_after_writing if connected?
       @close_df = EM::DefaultDeferrable.new
     end
 
-    def force_reconnect
-      @intentionally_closed = false
-      @conn.close_connection if connected?
-    end
-
     def disconnected
       @connected = false
-      if @intentionally_closed
+      if @desired_state == :disconnected
         @close_df.succeed
       else
         d = @deferrables.dup
@@ -327,13 +324,10 @@ module EMJack
     end
 
     def reconnect!
-      @retries = 0
-
-      reset_tube_state
-      EM.next_tick do
-        @conn.reconnect(@host, @port)
-        initialize_tube_state
-      end
+      # In order to force a reconnection, the connection is closed, but
+      # @desired_state is not changed to :disconnected, so reconnect logic will
+      # be called in the disconnected handler
+      @conn.close_connection if connected?
     end
 
     def add_deferrable(&blk)

--- a/spec/em-jack/connection_spec.rb
+++ b/spec/em-jack/connection_spec.rb
@@ -434,6 +434,16 @@ describe EMJack::Connection do
       conn.disconnected
       conn.connected?.should == false
     end
+
+    it "closes connection immediately and reconnects on force_reconnect" do
+      EM.should_receive(:add_timer).exactly(1).times.and_yield
+      connection_mock.should_receive :close_connection
+      connection_mock.should_receive :reconnect
+
+      conn.force_reconnect
+      conn.disconnected
+      conn.connected?.should == false
+    end
   end
 
   describe 'beanstalk responses' do

--- a/spec/em-jack/connection_spec.rb
+++ b/spec/em-jack/connection_spec.rb
@@ -440,7 +440,7 @@ describe EMJack::Connection do
       connection_mock.should_receive :close_connection
       connection_mock.should_receive :reconnect
 
-      conn.force_reconnect
+      conn.reconnect!
       conn.disconnected
       conn.connected?.should == false
     end


### PR DESCRIPTION
Consumers of the library can set timeouts on operations and force a
reconnect in the event of timeouts. This moves bad connections more
quickly into a disconnected state, allowing consumers to remove them
from the connection pool into a new connection has been successfully
established. For example, in the [jobsworth](https://github.com/pusher/jobsworth):

```
            c.put(@marshaller.dump(job), options).timeout(@timeout).errback {
              @logger.warn("put timed out to #{c.host}")
              if c.connected?
                @logger.info("forcing reconnect to #{c.host}")
                c.force_reconnect
              end
            }
```

There is an argument that the semantics of `intentionally_closed`
don't quite fit with this use case - in the force_reconnect method, the
connection was `intentionally_closed` too - a better description might
be `desired_state = connected` or `should_be_connected`. Open to
suggestions